### PR TITLE
Fail CI if Stata code exited with an error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,3 +44,10 @@ fi
 
 # print log result
 cat main.log
+
+# Fail CI if Stata ran with an error
+EXIT_CODE=$(tail -1 main.log | tr -d '[:cntrl:]')
+
+if [[ ${EXIT_CODE:0:1} == "r" ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Currently, the CI succeed (implicit `exit 0`) all the time, even if the Stata code exited with an error. 
Indeed, `stata* -b do main.do` always exits with a 0 — even if the code didn't run successfully.

To check whether `main.do` was run successfully, one need to look at the last line of the log file:

- if the run is successful, then the last line is "end of do-file",
- else it is an error code of the form: "r(*);".

Failing the CI means exiting with a non-0 exit code — cf. [documentation](https://web.archive.org/web/20210125021854/https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions#setting-a-failure-exit-code-in-a-docker-container-action).

We here look at the last line of the logs and checks whether it matches the pattern of an error code (concretely, we check whether the first letter of the last line is `r`); if so, we exit with an error code.

Fixes #9